### PR TITLE
Update testing & CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,12 @@ jobs:
           - '1.4.8'
           - '1.6.0'
           - 'stable'
+          - 'devel'
     needs: before
     steps:
       - uses: actions/checkout@v1
       - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: ${{ matrix.nim-version }}
-      - run: nimble install -Y
-      - run: nimble tests -Y
+      - run: nimble install -y
+      - run: nimble test

--- a/bigints.nimble
+++ b/bigints.nimble
@@ -11,6 +11,6 @@ srcDir      = "src"
 
 requires "nim >= 1.4.0"
 
-task tests, "Test bigints":
-  exec "nim c -r tests/tester"
-  exec "nim c -r tests/tissue_27"
+task test, "Test bigints":
+  exec "nim r tests/tester"
+  exec "nim r tests/tissue_27"


### PR DESCRIPTION
* overwrite `nimble test` (failed before due to `tests/tliterals.nim`, more intuitive than `nimble tests`)
* use `nim r` instead of `nim c -r` (doesn't pollute `tests/` with compilation artifacts)
* test `devel` in CI