### PR TITLE
Do some cleanup

### DIFF
--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -28,10 +28,10 @@ proc initBigInt*(vals: sink seq[uint32], isNegative = false): BigInt =
 
 proc initBigInt*[T: int8|int16|int32](val: T): BigInt =
   if val < 0:
-    result.limbs = @[(not val.int32).uint32 + 1]
+    result.limbs = @[(not val).uint32 + 1] # manual 2's complement (to avoid overflow)
     result.isNegative = true
   else:
-    result.limbs = @[val.int32.uint32]
+    result.limbs = @[val.uint32]
     result.isNegative = false
 
 proc initBigInt*[T: uint8|uint16|uint32](val: T): BigInt =
@@ -40,15 +40,15 @@ proc initBigInt*[T: uint8|uint16|uint32](val: T): BigInt =
 proc initBigInt*(val: int64): BigInt =
   var a = val.uint64
   if val < 0:
-    a = not a + 1
+    a = not a + 1 # 2's complement
     result.isNegative = true
-  if a > uint32.high.uint64:
+  if a > uint32.high:
     result.limbs = @[(a and uint32.high).uint32, (a shr 32).uint32]
   else:
     result.limbs = @[a.uint32]
 
 proc initBigInt*(val: uint64): BigInt =
-  if val > uint32.high.uint64:
+  if val > uint32.high:
     result.limbs = @[(val and uint32.high).uint32, (val shr 32).uint32]
   else:
     result.limbs = @[val.uint32]
@@ -119,12 +119,7 @@ proc cmp(a: BigInt, b: int32): int64 =
   ## * a value greater than zero, if `a > b`
   ## * zero, if `a == b`
   if a.isZero:
-    if b < 0:
-      return 1
-    elif b == 0:
-      return 0
-    else:
-      return -1
+    return -b.int64
   elif a.isNegative:
     if b < 0:
       return unsignedCmp(b, a)
@@ -861,13 +856,11 @@ proc initBigInt*(str: string, base: range[2..36] = 10): BigInt =
   var mul = one
   let size = sizes[base]
   var first = 0
-  var str = str
   var neg = false
 
   if str[0] == '-':
     first = 1
     neg = true
-    str[0] = '0'
 
   for i in countdown((str.high div size) * size, 0, size):
     var smul = 1'u32
@@ -915,25 +908,25 @@ proc dec*(a: var BigInt, b: int32 = 1) =
   subtractionInt(a, c, b)
 
 
-iterator countup*(a, b: BigInt, step: int32 = 1): BigInt {.inline.} =
+iterator countup*(a, b: BigInt, step: int32 = 1): BigInt =
   var res = a
   while res <= b:
     yield res
     inc(res, step)
 
-iterator countdown*(a, b: BigInt, step: int32 = 1): BigInt {.inline.} =
+iterator countdown*(a, b: BigInt, step: int32 = 1): BigInt =
   var res = a
   while res >= b:
     yield res
     dec(res, step)
 
-iterator `..`*(a, b: BigInt): BigInt {.inline.} =
+iterator `..`*(a, b: BigInt): BigInt =
   var res = a
   while res <= b:
     yield res
     inc res
 
-iterator `..<`*(a, b: BigInt): BigInt {.inline.} =
+iterator `..<`*(a, b: BigInt): BigInt =
   var res = a
   while res < b:
     yield res

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -1,4 +1,4 @@
-import bigints, unittest
+import bigints, std/unittest
 
 const
   zero = initBigInt(0)
@@ -47,14 +47,12 @@ test "initBigInt":
           chk (v and int32.high.uint64).int32
           chk (v and uint32.high).uint32
 
-
 when (NimMajor, NimMinor) >= (1, 5):
   test "literals":
     # workaround
     include tliterals
 
-
-test "range of bigint (https://github.com/def-/nim-bigints/issues/1)":
+test "range of bigint (https://github.com/nim-lang/bigints/issues/1)":
   let two = 2.initBigInt
   let n = "123".initBigInt
   var result = 1.initBigInt
@@ -62,7 +60,7 @@ test "range of bigint (https://github.com/def-/nim-bigints/issues/1)":
     result *= i
   check result == initBigInt("12146304367025329675766243241881295855454217088483382315328918161829235892362167668831156960612640202170735835221294047782591091570411651472186029519906261646730733907419814952960000000000000000000000000000")
 
-test "multiple multiplications (https://github.com/def-/nim-bigints/issues/3)":
+test "multiple multiplications (https://github.com/nim-lang/bigints/issues/3)":
   let nums = [ "68855123440532288245010625",
                "201850901852714536181760000",
                "435980903974422631450250625",
@@ -78,11 +76,11 @@ test "multiple multiplications (https://github.com/def-/nim-bigints/issues/3)":
 
   check total == initBigInt("1091531901753858845417645933677882391421406095571139520376889755608568225321090455009925801178698945969179844505331560015898829746339840000000000000000000000")
 
-test "negative bigint (https://github.com/def-/nim-bigints/issues/4)":
+test "negative bigint (https://github.com/nim-lang/bigints/issues/4)":
   let x = -initBigInt(1)
   check x == initBigInt(-1)
 
-test "off by one in division (https://github.com/def-/nim-bigints/issues/5)":
+test "off by one in division (https://github.com/nim-lang/bigints/issues/5)":
   block:
     var x = initBigInt("815915283247897734345611269596115894272000000000")
     var y = initBigInt("5919012181389927685417441689600000000")
@@ -93,7 +91,7 @@ test "off by one in division (https://github.com/def-/nim-bigints/issues/5)":
     var y = initBigInt("20000000000")
     check x div y == initBigInt("40795764162394886717280563479805794713")
 
-test "negative zero flags (https://github.com/def-/nim-bigints/issues/16)":
+test "negative zero flags (https://github.com/nim-lang/bigints/issues/16)":
   let
     a = initBigInt("828478292990482")
     b = initBigInt(9283)
@@ -113,7 +111,7 @@ test "negative zero flags (https://github.com/def-/nim-bigints/issues/16)":
   check b * e == e
   check e div d == e
 
-test "validate digits in string parsing (https://github.com/def-/nim-bigints/issues/22)":
+test "validate digits in string parsing (https://github.com/nim-lang/bigints/issues/22)":
   check initBigInt("1", 2) == initBigInt(1)
   check initBigInt("z", 36) == initBigInt(35)
   expect ValueError:
@@ -121,7 +119,7 @@ test "validate digits in string parsing (https://github.com/def-/nim-bigints/iss
   expect ValueError:
     discard initBigInt("z", 35)
 
-test "empty limbs when uninitialized (https://github.com/def-/nim-bigints/issues/26)":
+test "empty limbs when uninitialized (https://github.com/nim-lang/bigints/issues/26)":
   # reported issue has an example about multiplication and it is due to a call to a.limbs[0] for an uninitialized a: BigInt
   # besides multiplication, one could look at appearances of [0] in source to find possible failures
   # failures bound to reaching a line with [0] are fatal
@@ -189,13 +187,13 @@ test "empty limbs when uninitialized (https://github.com/def-/nim-bigints/issues
   check one * zeroEmpty == zero
   check one * -zeroEmpty == zero
 
-  # https://github.com/def-/nim-bigints/issues/26
+  # https://github.com/nim-lang/bigints/issues/26
   block:
     var
       a: BigInt
       b: BigInt = 12.initBigInt
 
-    check a*b == 0.initBigInt
+    check a * b == 0.initBigInt
 
   # division does not have issues, but let's add some checks
   check zeroEmpty div one == zero


### PR DESCRIPTION
* remove unnecessary conversions
* remove unnecessary `{.inline.}` pragmas for iterators (iterators are inline by default)
* simplify `cmp(BigInt, int32)`
* remove unnecessary `var str = str` in `initBigInt(string, range[2..36])`
* update issue links in test suite