### PR TITLE
Simplify test task & possibly fix 32 bit

### DIFF
--- a/bigints.nimble
+++ b/bigints.nimble
@@ -12,7 +12,7 @@ srcDir      = "src"
 requires "nim >= 1.4.0"
 
 task test, "Test bigints":
-  exec "nim r --backend:c tests/tbigints.nim"
-  exec "nim r --backend:c tests/tbugs.nim"
-  exec "nim r --backend:cpp tests/tbigints.nim"
-  exec "nim r --backend:cpp tests/tbugs.nim"
+  for backend in ["c", "cpp"]:
+    echo "testing " & backend & " backend"
+    for file in ["tbigints.nim", "tbugs.nim"]:
+      exec "nim r --hints:off --backend:" & backend & " tests/" & file

--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -758,7 +758,7 @@ proc `divmod`*(a, b: BigInt): tuple[q, r: BigInt] =
 
 proc calcSizes(): array[2..36, int] =
   for i in 2..36:
-    var x = i
+    var x = int64(i)
     while x <= int64(uint32.high) + 1:
       x *= i
       result[i].inc


### PR DESCRIPTION
The test task now iterates over an array of backends to check and an array of files to test. I also turned off the hints, because I found them annoying. On the other hand, it now prints the backend currently being tested.

I changed an `int` in `calcSizes` (that would overflow on 32 bit platforms) to an `int64`. As far as I can tell, this was the only `int` possibly overflowing, so perhaps this library now works on 32 bit platforms (refs #48). It would be good if someone could run the tests on a 32 bit machine (I unfortunately don't have access to one and it doesn't seem like GitHub actions have either), perhaps @def- (since you originally reported tests failing on 32 bit platforms)?