### PR TITLE
Add powmod to BigInt

### DIFF
--- a/examples/rc_hammingnumbers.nim
+++ b/examples/rc_hammingnumbers.nim
@@ -11,7 +11,7 @@ proc hamming(limit: int): BigInt =
     i, j, k = 0
   for i in 0..h.high: h[i] = initBigInt(1)
 
-  for n in 1 .. < limit:
+  for n in 1 ..< limit:
     h[n] = min([x2, x3, x5])
     if x2 == h[n]:
       inc i

--- a/examples/rc_paraffins.nim
+++ b/examples/rc_paraffins.nim
@@ -15,7 +15,7 @@ for i in 2 .. nMax:
 proc choose(m: BigInt, k: int32): BigInt =
   result = m
   if k == 1: return
-  for i in 1 .. < k:
+  for i in 1 ..< k:
     result = result * (m + i) div (i + 1)
 
 proc tree(br, n, l, sum: int32, cnt: BigInt) =

--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -959,3 +959,33 @@ iterator `..<`*(a, b: BigInt): BigInt =
   while res < b:
     yield res
     inc res
+
+func powmod*(base, exponent, modulus: BigInt): BigInt =
+  ## Compute modular exponentation of `base` with power `exponent` modulo `modulus`.
+  if modulus == 0:
+    raise newException(DivByZeroDefect, "modulus must be nonzero.")
+  if modulus == 1:
+    return zero
+  if exponent < 0:
+    # let baseInv = inverse_mod(base, modulus)
+    # return powmod(baseInv, -exponent, modulus)
+    raise newException(ValueError, "Not yet Implemented!")
+  if exponent == 0:
+    if base == 0:
+      raise newException(ValueError, "0^0 is undefined.")
+    return one
+
+  var
+    exp = exponent
+    basePow = ((base mod modulus) + modulus) mod modulus # Base stays in [0, m-1]
+  while (exp and one) == zero:
+    basePow = basePow * basePow mod modulus
+    exp = exp shr 1
+  result = basePow
+  exp = exp shr 1
+  while exp != zero:
+    basePow = (basePow*basePow) mod modulus
+    if (exp and one) != zero:
+      result = (result*basePow) mod modulus
+    exp = exp shr 1
+

--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -9,14 +9,14 @@ type
     isNegative: bool
 
 
-proc normalize(a: var BigInt) =
+func normalize(a: var BigInt) =
   for i in countdown(a.limbs.high, 0):
     if a.limbs[i] > 0'u32:
       a.limbs.setLen(i+1)
       return
   a.limbs.setLen(1)
 
-proc initBigInt*(vals: sink seq[uint32], isNegative = false): BigInt =
+func initBigInt*(vals: sink seq[uint32], isNegative = false): BigInt =
   ## Initializes a `BigInt` from a sequence of `uint32` values.
   runnableExamples:
     let a = @[10'u32, 2'u32].initBigInt
@@ -25,7 +25,7 @@ proc initBigInt*(vals: sink seq[uint32], isNegative = false): BigInt =
   result.limbs = vals
   result.isNegative = isNegative
 
-proc initBigInt*[T: int8|int16|int32](val: T): BigInt =
+func initBigInt*[T: int8|int16|int32](val: T): BigInt =
   if val < 0:
     result.limbs = @[(not val).uint32 + 1] # manual 2's complement (to avoid overflow)
     result.isNegative = true
@@ -33,10 +33,10 @@ proc initBigInt*[T: int8|int16|int32](val: T): BigInt =
     result.limbs = @[val.uint32]
     result.isNegative = false
 
-proc initBigInt*[T: uint8|uint16|uint32](val: T): BigInt =
+func initBigInt*[T: uint8|uint16|uint32](val: T): BigInt =
   result.limbs = @[val.uint32]
 
-proc initBigInt*(val: int64): BigInt =
+func initBigInt*(val: int64): BigInt =
   var a = val.uint64
   if val < 0:
     a = not a + 1 # 2's complement
@@ -46,7 +46,7 @@ proc initBigInt*(val: int64): BigInt =
   else:
     result.limbs = @[a.uint32]
 
-proc initBigInt*(val: uint64): BigInt =
+func initBigInt*(val: uint64): BigInt =
   if val > uint32.high:
     result.limbs = @[(val and uint32.high).uint32, (val shr 32).uint32]
   else:
@@ -59,29 +59,29 @@ else:
   template initBigInt*(val: int): BigInt = initBigInt(val.int64)
   template initBigInt*(val: uint): BigInt = initBigInt(val.uint64)
 
-proc initBigInt*(val: BigInt): BigInt =
+func initBigInt*(val: BigInt): BigInt =
   result = val
 
 const
   zero = initBigInt(0)
   one = initBigInt(1)
 
-proc isZero(a: BigInt): bool {.inline.} =
+func isZero(a: BigInt): bool {.inline.} =
   for i in countdown(a.limbs.high, 0):
     if a.limbs[i] != 0'u32:
       return false
   return true
 
-proc unsignedCmp(a: BigInt, b: uint32): int64 =
+func unsignedCmp(a: BigInt, b: uint32): int64 =
   # ignores the sign of `a`
   # `a` and `b` are assumed to not be zero
   result = int64(a.limbs.len) - 1
   if result != 0: return
   result = int64(a.limbs[0]) - int64(b)
 
-proc unsignedCmp(a: uint32, b: BigInt): int64 = -unsignedCmp(b, a)
+func unsignedCmp(a: uint32, b: BigInt): int64 = -unsignedCmp(b, a)
 
-proc unsignedCmp(a, b: BigInt): int64 =
+func unsignedCmp(a, b: BigInt): int64 =
   # ignores the signs of `a` and `b`
   # `a` and `b` are assumed to not be zero
   result = int64(a.limbs.len) - int64(b.limbs.len)
@@ -91,7 +91,7 @@ proc unsignedCmp(a, b: BigInt): int64 =
     if result != 0:
       return
 
-proc cmp(a, b: BigInt): int64 =
+func cmp(a, b: BigInt): int64 =
   ## Returns:
   ## * a value less than zero, if `a < b`
   ## * a value greater than zero, if `a > b`
@@ -114,7 +114,7 @@ proc cmp(a, b: BigInt): int64 =
     else:
       return unsignedCmp(a, b)
 
-proc cmp(a: BigInt, b: int32): int64 =
+func cmp(a: BigInt, b: int32): int64 =
   ## Returns:
   ## * a value less than zero, if `a < b`
   ## * a value greater than zero, if `a > b`
@@ -132,9 +132,9 @@ proc cmp(a: BigInt, b: int32): int64 =
     else:
       return unsignedCmp(a, b.uint32)
 
-proc cmp(a: int32, b: BigInt): int64 = -cmp(b, a)
+func cmp(a: int32, b: BigInt): int64 = -cmp(b, a)
 
-proc `==`*(a, b: BigInt): bool =
+func `==`*(a, b: BigInt): bool =
   ## Compares if two `BigInt` numbers are equal.
   runnableExamples:
     let
@@ -145,7 +145,7 @@ proc `==`*(a, b: BigInt): bool =
     assert b != c
   cmp(a, b) == 0
 
-proc `<`*(a, b: BigInt): bool =
+func `<`*(a, b: BigInt): bool =
   runnableExamples:
     let
       a = 5.initBigInt
@@ -155,7 +155,7 @@ proc `<`*(a, b: BigInt): bool =
     assert b > c
   cmp(a, b) < 0
 
-proc `<=`*(a, b: BigInt): bool =
+func `<=`*(a, b: BigInt): bool =
   runnableExamples:
     let
       a = 5.initBigInt
@@ -165,16 +165,16 @@ proc `<=`*(a, b: BigInt): bool =
     assert c <= b
   cmp(a, b) <= 0
 
-proc `==`(a: BigInt, b: int32): bool = cmp(a, b) == 0
-proc `<`(a: BigInt, b: int32): bool = cmp(a, b) < 0
-proc `<`(a: int32, b: BigInt): bool = cmp(a, b) < 0
+func `==`(a: BigInt, b: int32): bool = cmp(a, b) == 0
+func `<`(a: BigInt, b: int32): bool = cmp(a, b) < 0
+func `<`(a: int32, b: BigInt): bool = cmp(a, b) < 0
 
 template addParts(toAdd) =
   tmp += toAdd
   a.limbs[i] = uint32(tmp and uint32.high)
   tmp = tmp shr 32
 
-proc unsignedAdditionInt(a: var BigInt, b: BigInt, c: uint32) =
+func unsignedAdditionInt(a: var BigInt, b: BigInt, c: uint32) =
   let bl = b.limbs.len
   a.limbs.setLen(bl)
 
@@ -185,7 +185,7 @@ proc unsignedAdditionInt(a: var BigInt, b: BigInt, c: uint32) =
     a.limbs.add(uint32(tmp))
   a.isNegative = false
 
-proc unsignedAddition(a: var BigInt, b, c: BigInt) =
+func unsignedAddition(a: var BigInt, b, c: BigInt) =
   let
     bl = b.limbs.len
     cl = c.limbs.len
@@ -205,10 +205,10 @@ proc unsignedAddition(a: var BigInt, b, c: BigInt) =
     a.limbs.add(uint32(tmp))
   a.isNegative = false
 
-proc negate(a: var BigInt) =
+func negate(a: var BigInt) =
   a.isNegative = not a.isNegative
 
-proc `-`*(a: BigInt): BigInt =
+func `-`*(a: BigInt): BigInt =
   ## Unary minus for `BigInt`.
   runnableExamples:
     let
@@ -263,7 +263,7 @@ template realUnsignedSubtraction(a: var BigInt, b, c: BigInt) =
   normalize(a)
   assert tmp == 0
 
-proc unsignedSubtractionInt(a: var BigInt, b: BigInt, c: uint32) =
+func unsignedSubtractionInt(a: var BigInt, b: BigInt, c: uint32) =
   # `b` is not zero
   let cmpRes = unsignedCmp(b, c)
   if cmpRes > 0:
@@ -275,7 +275,7 @@ proc unsignedSubtractionInt(a: var BigInt, b: BigInt, c: uint32) =
   else: # b == c
     a = zero
 
-proc unsignedSubtraction(a: var BigInt, b, c: BigInt) =
+func unsignedSubtraction(a: var BigInt, b, c: BigInt) =
   let cmpRes = unsignedCmp(b, c)
   if cmpRes > 0:
     realUnsignedSubtraction(a, b, c)
@@ -285,7 +285,7 @@ proc unsignedSubtraction(a: var BigInt, b, c: BigInt) =
   else: # b == c
     a = zero
 
-proc additionInt(a: var BigInt, b: BigInt, c: int32) =
+func additionInt(a: var BigInt, b: BigInt, c: int32) =
   # a = b + c
   if b.isZero:
     a = c.initBigInt
@@ -301,7 +301,7 @@ proc additionInt(a: var BigInt, b: BigInt, c: int32) =
     else:
       unsignedAdditionInt(a, b, c.uint32)
 
-proc addition(a: var BigInt, b, c: BigInt) =
+func addition(a: var BigInt, b, c: BigInt) =
   # a = b + c
   if b.isNegative:
     if c.isNegative:
@@ -315,7 +315,7 @@ proc addition(a: var BigInt, b, c: BigInt) =
     else:
       unsignedAddition(a, b, c)
 
-proc `+`*(a, b: BigInt): BigInt =
+func `+`*(a, b: BigInt): BigInt =
   ## Addition for `BigInt`s.
   runnableExamples:
     let
@@ -333,7 +333,7 @@ template `+=`*(a: var BigInt, b: BigInt) =
     assert a == 7.initBigInt
   a = a + b
 
-proc subtractionInt(a: var BigInt, b: BigInt, c: int32) =
+func subtractionInt(a: var BigInt, b: BigInt, c: int32) =
   # a = b - c
   if b.isZero:
     a = -c.initBigInt
@@ -349,7 +349,7 @@ proc subtractionInt(a: var BigInt, b: BigInt, c: int32) =
     else:
       unsignedSubtractionInt(a, b, c.uint32)
 
-proc subtraction(a: var BigInt, b, c: BigInt) =
+func subtraction(a: var BigInt, b, c: BigInt) =
   # a = b - c
   if b.isNegative:
     if c.isNegative:
@@ -363,7 +363,7 @@ proc subtraction(a: var BigInt, b, c: BigInt) =
     else:
       unsignedSubtraction(a, b, c)
 
-proc `-`*(a, b: BigInt): BigInt =
+func `-`*(a, b: BigInt): BigInt =
   ## Subtraction for `BigInt`s.
   runnableExamples:
     let
@@ -382,7 +382,7 @@ template `-=`*(a: var BigInt, b: BigInt) =
   a = a - b
 
 
-proc unsignedMultiplication(a: var BigInt, b, c: BigInt) {.inline.} =
+func unsignedMultiplication(a: var BigInt, b, c: BigInt) {.inline.} =
   # always called with bl >= cl
   let
     bl = b.limbs.len
@@ -411,7 +411,7 @@ proc unsignedMultiplication(a: var BigInt, b, c: BigInt) {.inline.} =
       inc pos
   normalize(a)
 
-proc multiplication(a: var BigInt, b, c: BigInt) =
+func multiplication(a: var BigInt, b, c: BigInt) =
   # a = b * c
   if b.isZero or c.isZero:
     a = zero
@@ -426,7 +426,7 @@ proc multiplication(a: var BigInt, b, c: BigInt) =
     unsignedMultiplication(a, b, c)
   a.isNegative = b.isNegative xor c.isNegative
 
-proc `*`*(a, b: BigInt): BigInt =
+func `*`*(a, b: BigInt): BigInt =
   ## Multiplication for `BigInt`s.
   runnableExamples:
     let
@@ -442,7 +442,7 @@ template `*=`*(a: var BigInt, b: BigInt) =
     assert a == 150.initBigInt
   a = a * b
 
-proc pow*(x: BigInt, y: Natural): BigInt =
+func pow*(x: BigInt, y: Natural): BigInt =
   ## Computes `x` to the power of `y`.
   var base = x
   var exp = y
@@ -455,7 +455,7 @@ proc pow*(x: BigInt, y: Natural): BigInt =
     exp = exp shr 1
     base *= base
 
-proc `shl`*(x: BigInt, y: Natural): BigInt =
+func `shl`*(x: BigInt, y: Natural): BigInt =
   ## Shifts a `BigInt` to the left.
   runnableExamples:
     let a = 24.initBigInt
@@ -478,9 +478,9 @@ proc `shl`*(x: BigInt, y: Natural): BigInt =
     result.limbs.add(uint32(carry shr (32 - b)))
 
 # forward declaration for use in `shr`
-proc dec*(a: var BigInt, b: int32 = 1)
+func dec*(a: var BigInt, b: int32 = 1)
 
-proc `shr`*(x: BigInt, y: Natural): BigInt =
+func `shr`*(x: BigInt, y: Natural): BigInt =
   ## Shifts a `BigInt` to the right (arithmetically).
   runnableExamples:
     let a = 24.initBigInt
@@ -516,17 +516,17 @@ proc `shr`*(x: BigInt, y: Natural): BigInt =
     # normalize
     result.limbs.setLen(result.limbs.high)
 
-proc bitwiseAnd(a: var BigInt, b, c: BigInt) =
+func bitwiseAnd(a: var BigInt, b, c: BigInt) =
   a.limbs.setLen(min(b.limbs.len, c.limbs.len))
   for i in 0 ..< a.limbs.len:
     a.limbs[i] = b.limbs[i] and c.limbs[i]
 
-proc `and`*(a, b: BigInt): BigInt =
+func `and`*(a, b: BigInt): BigInt =
   ## Bitwise `and` for `BigInt`s.
   assert (not a.isNegative) and (not b.isNegative)
   bitwiseAnd(result, a, b)
 
-proc bitwiseOr(a: var BigInt, b, c: BigInt) =
+func bitwiseOr(a: var BigInt, b, c: BigInt) =
   # `b` must be smaller than `c`
   a.limbs.setLen(c.limbs.len)
   for i in 0 ..< b.limbs.len:
@@ -534,7 +534,7 @@ proc bitwiseOr(a: var BigInt, b, c: BigInt) =
   for i in b.limbs.len ..< c.limbs.len:
     a.limbs[i] = c.limbs[i]
 
-proc `or`*(a, b: BigInt): BigInt =
+func `or`*(a, b: BigInt): BigInt =
   ## Bitwise `or` for `BigInt`s.
   assert (not a.isNegative) and (not b.isNegative)
   if a.limbs.len <= b.limbs.len:
@@ -542,7 +542,7 @@ proc `or`*(a, b: BigInt): BigInt =
   else:
     bitwiseOr(result, b, a)
 
-proc bitwiseXor(a: var BigInt, b, c: BigInt) =
+func bitwiseXor(a: var BigInt, b, c: BigInt) =
   # `b` must be smaller than `c`
   a.limbs.setLen(c.limbs.len)
   for i in 0 ..< b.limbs.len:
@@ -550,7 +550,7 @@ proc bitwiseXor(a: var BigInt, b, c: BigInt) =
   for i in b.limbs.len ..< c.limbs.len:
     a.limbs[i] = c.limbs[i]
 
-proc `xor`*(a, b: BigInt): BigInt =
+func `xor`*(a, b: BigInt): BigInt =
   ## Bitwise `xor` for `BigInt`s.
   assert (not a.isNegative) and (not b.isNegative)
   if a.limbs.len <= b.limbs.len:
@@ -558,13 +558,13 @@ proc `xor`*(a, b: BigInt): BigInt =
   else:
     bitwiseXor(result, b, a)
 
-proc reset(a: var BigInt) =
+func reset(a: var BigInt) =
   ## Resets a `BigInt` back to the zero value.
   a.limbs.setLen(1)
   a.limbs[0] = 0
   a.isNegative = false
 
-proc unsignedDivRem(q: var BigInt, r: var uint32, n: BigInt, d: uint32) =
+func unsignedDivRem(q: var BigInt, r: var uint32, n: BigInt, d: uint32) =
   q.limbs.setLen(n.limbs.len)
   r = 0
   for i in countdown(n.limbs.high, 0):
@@ -574,7 +574,7 @@ proc unsignedDivRem(q: var BigInt, r: var uint32, n: BigInt, d: uint32) =
   while q.limbs.len > 1 and q.limbs[q.limbs.high] == 0:
     q.limbs.setLen(q.limbs.high)
 
-proc bits(d: uint32): int =
+func bits(d: uint32): int =
   const bitLengths = [0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4,
                       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]
   var d = d
@@ -584,7 +584,7 @@ proc bits(d: uint32): int =
   result += bitLengths[int(d)]
 
 # From Knuth and Python
-proc unsignedDivRem(q, r: var BigInt, n, d: BigInt) =
+func unsignedDivRem(q, r: var BigInt, n, d: BigInt) =
   var
     nn = n.limbs.len
     dn = d.limbs.len
@@ -695,7 +695,7 @@ proc unsignedDivRem(q, r: var BigInt, n, d: BigInt) =
     q = a
     normalize(q)
 
-proc division(q, r: var BigInt, n, d: BigInt) =
+func division(q, r: var BigInt, n, d: BigInt) =
   unsignedDivRem(q, r, n, d)
 
   q.isNegative = n < 0 xor d < 0
@@ -713,10 +713,10 @@ proc division(q, r: var BigInt, n, d: BigInt) =
   if r.limbs == @[0'u32]:
     r.isNegative = false
 
-proc `div`*(a, b: BigInt): BigInt =
+func `div`*(a, b: BigInt): BigInt =
   ## Computes the integer division of two `BigInt` numbers.
   ##
-  ## If you also need the modulo (remainder), use the `divmod proc <#divmod,BigInt,BigInt>`_.
+  ## If you also need the modulo (remainder), use the `divmod func <#divmod,BigInt,BigInt>`_.
   runnableExamples:
     let
       a = 17.initBigInt
@@ -728,10 +728,10 @@ proc `div`*(a, b: BigInt): BigInt =
   var tmp: BigInt
   division(result, tmp, a, b)
 
-proc `mod`*(a, b: BigInt): BigInt =
+func `mod`*(a, b: BigInt): BigInt =
   ## Computes the integer modulo (remainder) of two `BigInt` numbers.
   ##
-  ## If you also need an integer division, use the `divmod proc <#divmod,BigInt,BigInt>`_.
+  ## If you also need an integer division, use the `divmod func <#divmod,BigInt,BigInt>`_.
   runnableExamples:
     let
       a = 17.initBigInt
@@ -743,7 +743,7 @@ proc `mod`*(a, b: BigInt): BigInt =
   var tmp: BigInt
   division(tmp, result, a, b)
 
-proc `divmod`*(a, b: BigInt): tuple[q, r: BigInt] =
+func `divmod`*(a, b: BigInt): tuple[q, r: BigInt] =
   ## Computes both the integer division and modulo (remainder) of two
   ## `BigInt` numbers.
   runnableExamples:
@@ -756,7 +756,7 @@ proc `divmod`*(a, b: BigInt): tuple[q, r: BigInt] =
   division(result.q, result.r, a, b)
 
 
-proc calcSizes(): array[2..36, int] =
+func calcSizes(): array[2..36, int] =
   for i in 2..36:
     var x = i
     while x <= int64(uint32.high) + 1:
@@ -768,7 +768,7 @@ const
   powers = {2, 4, 8, 16, 32}
   sizes = calcSizes() # `sizes[base]` is the maximum number of digits that fully fit in a `uint32`
 
-proc toString*(a: BigInt, base: range[2..36] = 10): string =
+func toString*(a: BigInt, base: range[2..36] = 10): string =
   ## Produces a string representation of a `BigInt` in a specified
   ## `base`.
   ##
@@ -833,11 +833,11 @@ proc toString*(a: BigInt, base: range[2..36] = 10): string =
 
   result.reverse()
 
-proc `$`*(a: BigInt): string =
+func `$`*(a: BigInt): string =
   ## String representation of a `BigInt` in base 10.
   toString(a, 10)
 
-proc parseDigit(c: char, base: uint32): uint32 {.inline.} =
+func parseDigit(c: char, base: uint32): uint32 {.inline.} =
   result = case c
     of '0'..'9': uint32(ord(c) - ord('0'))
     of 'a'..'z': uint32(ord(c) - ord('a') + 10)
@@ -847,7 +847,7 @@ proc parseDigit(c: char, base: uint32): uint32 {.inline.} =
   if result >= base:
     raise newException(ValueError, "Invalid input: " & c)
 
-proc initBigInt*(str: string, base: range[2..36] = 10): BigInt =
+func initBigInt*(str: string, base: range[2..36] = 10): BigInt =
   ## Create a `BigInt` from a string. For invalid inputs, a `ValueError` exception is raised.
   runnableExamples:
     let
@@ -909,7 +909,7 @@ proc initBigInt*(str: string, base: range[2..36] = 10): BigInt =
 when (NimMajor, NimMinor) >= (1, 5):
   include bigints/private/literals
 
-proc inc*(a: var BigInt, b: int32 = 1) =
+func inc*(a: var BigInt, b: int32 = 1) =
   ## Increase the value of a `BigInt` by the specified amount (default: 1).
   runnableExamples:
     var a = 15.initBigInt
@@ -920,7 +920,7 @@ proc inc*(a: var BigInt, b: int32 = 1) =
   var c = a
   additionInt(a, c, b)
 
-proc dec*(a: var BigInt, b: int32 = 1) =
+func dec*(a: var BigInt, b: int32 = 1) =
   ## Decrease the value of a `BigInt` by the specified amount (default: 1).
   runnableExamples:
     var a = 15.initBigInt

--- a/tests/tbigints.nim
+++ b/tests/tbigints.nim
@@ -379,5 +379,37 @@ template main() =
     doAssert pow(zero, 0) == one
     doAssert pow(zero, 1) == zero
 
+  block: #pow_mod
+    let a = "30292868".initBigInt
+    let p = "60449131".initBigInt # p is prime
+    let two = 2.initBigInt
+    doAssert powmod(a, two, p) == "25760702".initBigInt
+    # Fermat's little theorem: a^p ≡ a, for all a in F_p
+    doAssert powmod(a, p, p) == a
+    # Euler's identity a^(p-1) \equiv 1 \bmod p
+    doAssert powmod(a, p - one, p) == one
+    # We can invert a using euler's identity / fermat's little theorem
+    doAssert powmod(a, p - two, p) == "51713091".initBigInt
+    # We can reduce the exponent modulo phi(p) = p - 1, since p is prime
+    doAssert powmod(a, 2.initBigInt*p, p) == (a*a mod p)
+
+    let p2 = 761.initBigInt
+    var a2 = 1.initBigInt
+    # Fermat's little theorem: a^p ≡ a, for all a in F_p
+    while a2 < p2:
+      doAssert powmod(a2, p2, p2) == a2
+      a2.inc
+
+  block:
+    # Composite modulus
+    let a = "2472018".initBigInt
+    let n = "3917515".initBigInt # 5 * 7 * 19 * 43 * 137
+    let euler_phi = "2467584".initBigInt
+    doAssert powmod(a, 52.initBigInt, n) == "2305846".initBigInt
+    doAssert powmod(a, euler_phi, n) == one
+    # Edge cases
+    doAssert powmod(a, one, n) == a
+    doAssert powmod(a, zero, n) == one
+
 static: main()
 main()


### PR DESCRIPTION
Following request of Issue #45, I have implemented modular exponentiation following SageMath implementation. The only discrepancy being it does not yet accept negative exponent.
I have added some tests too. Some checks uses mathematical properties as the little fermat's theorem. We might want to reduce them in the future, as they take a little time.
For negative exponentiation, we need to invert first using an extended euclidean algorithm.
Some examples did not compile anymore, due to a change to the backwards index operator .. < needs to be written as ..< .