### PR TITLE
Add gcd and abs with tests

### DIFF
--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -960,7 +960,9 @@ iterator `..<`*(a, b: BigInt): BigInt =
     yield res
     inc res
 
-func abs*(a: BigInt): BigInt = max(a, -a)
+func abs*(a: BigInt): BigInt =
+  result = a
+  result.isNegative = false
 
 func gcd*(a, b: BigInt): BigInt =
   ## Returns the greatest common divisor of `a` and `b`.

--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -959,3 +959,37 @@ iterator `..<`*(a, b: BigInt): BigInt =
   while res < b:
     yield res
     inc res
+
+func abs*(a: BigInt): BigInt = max(a, -a)
+
+func gcd*(a, b: BigInt): BigInt =
+  ## Returns the greatest common divisor of `a` and `b`.
+  if a.isZero:
+    return b
+  elif b.isZero:
+    return a
+  elif a < 0:
+    if b < 0:
+      return gcd(-a, -b)
+    else:
+      return gcd(-a, b)
+  elif b < 0:
+    return gcd(a, -b)
+  else:
+    var
+      u: BigInt = a
+      v: BigInt = b
+      t: BigInt = b
+      r: BigInt = a mod b
+    while v != 0:
+      t = v
+      r = u mod v
+      # v = min(r, r-v)
+      if r > (v shr 1):
+        v = v - r
+      else:
+        v = r
+      u = t
+    # We return abs(u)
+    result = abs(u)
+    

--- a/tests/tbigints.nim
+++ b/tests/tbigints.nim
@@ -379,5 +379,26 @@ template main() =
     doAssert pow(zero, 0) == one
     doAssert pow(zero, 1) == zero
 
+  block: # gcd
+    let a = "866506".initBigInt
+    let b = "140640".initBigInt
+    let two = 2.initBigInt
+    doAssert gcd(a, b) == two
+    # gcd(a, -b) = gcd(a, |b|)
+    doAssert gcd(-a, b) == two
+    doAssert gcd(a, -b) == two
+    doAssert gcd(-a, -b) == two
+
+  block: # properties of gcd
+    let a = "668403".initBigInt
+    let b = "753160".initBigInt
+    let c = "249115".initBigInt
+    doAssert gcd(a, b) == gcd(b, a)
+    doAssert gcd(a, zero) == a
+    doAssert gcd(a, a) == a
+    doAssert gcd(c*a, c*b) == c*gcd(a,b)
+    doAssert gcd(a, gcd(b, c)) == gcd(gcd(a, b), c)
+    doAssert gcd(a, b) == gcd(b, a mod b)
+
 static: main()
 main()


### PR DESCRIPTION
Implemented gcd with least absolute remainder (LAR) method.
I also implemented classical naïve gcd, and compared the two. Gcd tests are about twice faster with LAR so I kept only LAR method.
Implemented abs as max(a,-a).