### PR TITLE
Enable JS tests in VM if Nim version is >= 1.6

### DIFF
--- a/bigints.nimble
+++ b/bigints.nimble
@@ -12,7 +12,7 @@ srcDir      = "src"
 requires "nim >= 1.4.0"
 
 task test, "Test bigints":
-  for backend in ["c", "cpp"]:
+  for backend in ["c", "cpp", "js"]:
     echo "testing " & backend & " backend"
     for file in ["tbigints.nim", "tbugs.nim"]:
       exec "nim r --hints:off --experimental:strictFuncs --backend:" & backend & " tests/" & file

--- a/tests/tbigints.nim
+++ b/tests/tbigints.nim
@@ -455,7 +455,7 @@ proc main() =
     doAssert pred(a, 3) == initBigInt(4)
     doAssert succ(a, 3) == initBigInt(10)
 
-
-static: main()
+when (not defined(js)) or (NimMajor, NimMinor) >= (1, 6):
+  static: main()
 when not defined(js): # XXX: pending https://github.com/nim-lang/bigints/issues/59
   main()

--- a/tests/tbigints.nim
+++ b/tests/tbigints.nim
@@ -409,7 +409,7 @@ proc main() =
     doAssert toSignedInt[int](d) == some(i32h.int - 1)
     doAssert toSignedInt[int8](e) == none(int8)
     doAssert toSignedInt[int32](e) == none(int32)
-    doAssert toSignedInt[int](e) == some(i32h.int + 1)
+    doAssert toSignedInt[int64](e) == some(i32h.int64 + 1)
     doAssert toSignedInt[int8](f) == none(int8)
     doAssert toSignedInt[int32](f) == some(i32l)
     doAssert toSignedInt[int](f) == some(i32l.int)
@@ -418,35 +418,35 @@ proc main() =
     doAssert toSignedInt[int](g) == some(i32l.int + 1)
     doAssert toSignedInt[int8](h) == none(int8)
     doAssert toSignedInt[int32](h) == none(int32)
-    doAssert toSignedInt[int](h) == some(i32l.int - 1)
+    doAssert toSignedInt[int64](h) == some(i32l.int64 - 1)
 
     let
       i64h = int64.high
       i64l = int64.low
       i = initBigInt(i64h)
       j = initBigInt(i64h - 1)
-      k = initBigInt(uint64(int64.high) + 1'u64)
+      k = initBigInt(uint64(int64.high) + 1)
       l = initBigInt(i64l)
       m = initBigInt(i64l + 1)
       n = initBigInt("-9223372036854775809") # int64.low - 1
     doAssert toSignedInt[int8](i) == none(int8)
     doAssert toSignedInt[int32](i) == none(int32)
-    doAssert toSignedInt[int](i) == some(i64h.int)
+    doAssert toSignedInt[int64](i) == some(i64h)
     doAssert toSignedInt[int8](j) == none(int8)
     doAssert toSignedInt[int32](j) == none(int32)
-    doAssert toSignedInt[int](j) == some(i64h.int - 1)
+    doAssert toSignedInt[int64](j) == some(i64h - 1)
     doAssert toSignedInt[int8](k) == none(int8)
     doAssert toSignedInt[int32](k) == none(int32)
-    doAssert toSignedInt[int](k) == none(int)
+    doAssert toSignedInt[int64](k) == none(int64)
     doAssert toSignedInt[int8](l) == none(int8)
     doAssert toSignedInt[int32](l) == none(int32)
-    doAssert toSignedInt[int](l) == some(i64l.int)
+    doAssert toSignedInt[int64](l) == some(i64l)
     doAssert toSignedInt[int8](m) == none(int8)
     doAssert toSignedInt[int32](m) == none(int32)
-    doAssert toSignedInt[int](m) == some(i64l.int + 1)
+    doAssert toSignedInt[int64](m) == some(i64l + 1)
     doAssert toSignedInt[int8](n) == none(int8)
     doAssert toSignedInt[int32](n) == none(int32)
-    doAssert toSignedInt[int](n) == none(int)
+    doAssert toSignedInt[int64](n) == none(int64)
 
   block: # pred/succ
     let a = initBigInt(7)
@@ -457,4 +457,5 @@ proc main() =
 
 
 static: main()
-main()
+when not defined(js): # XXX: pending https://github.com/nim-lang/bigints/issues/59
+  main()

--- a/tests/tbugs.nim
+++ b/tests/tbugs.nim
@@ -1,6 +1,6 @@
 import bigints
 
-template main() =
+proc main() =
   block: # range of BigInt (https://github.com/nim-lang/bigints/issues/1)
     let two = 2.initBigInt
     let n = "123".initBigInt
@@ -84,4 +84,5 @@ template main() =
     a = a + b  # Error: unhandled exception: index out of bounds, the container is empty [IndexError]
 
 static: main()
-main()
+when not defined(js): # XXX: pending https://github.com/nim-lang/bigints/issues/59
+  main()

--- a/tests/tbugs.nim
+++ b/tests/tbugs.nim
@@ -83,6 +83,7 @@ proc main() =
 
     a = a + b  # Error: unhandled exception: index out of bounds, the container is empty [IndexError]
 
-static: main()
+when (not defined(js)) or (NimMajor, NimMinor) >= (1, 6):
+  static: main()
 when not defined(js): # XXX: pending https://github.com/nim-lang/bigints/issues/59
   main()


### PR DESCRIPTION
The tests are only run in the VM and only if the Nim version is >= 1.6, since unsigned integers are broken for JS otherwise (see #59). However, this has the advantage that we now effectively test a 32 bit target and it made me find & fix some bugs in the tests for `toSignedInt` that assumed 64 bit `int`s.