### PR TITLE
Optimize `succ`/`dec` for 32 bit values

### DIFF
--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -977,11 +977,19 @@ func dec*(a: var BigInt, b: int32 = 1) =
   var c = a
   subtractionInt(a, c, b)
 
-func succ*(a: BigInt, b = 1): BigInt =
-  result = a + initBigInt(b)
+func succ*(a: BigInt, b: int = 1): BigInt =
+  if b in int32.low..int32.high:
+    result = a
+    inc(result, b.int32)
+  else:
+    result = a + initBigInt(b)
 
-func pred*(a: BigInt, b = 1): BigInt =
-  result = a - initBigInt(b)
+func pred*(a: BigInt, b: int = 1): BigInt =
+  if b in int32.low..int32.high:
+    result = a
+    dec(result, b.int32)
+  else:
+    result = a - initBigInt(b)
 
 
 iterator countup*(a, b: BigInt, step: int32 = 1): BigInt =


### PR DESCRIPTION
This uses `inc`/`dec` if `b` is in the range of `int32` (which avoids allocating a temporary `BigInt`), at the cost of an additonal range check. I chose to not change the type from `int` to `int32`, since `succ`/`prec` for `Ordinal`s also take an `int` (we might want to make `inc`/`dec` take an `int` as well for the same reason). Although if you prefer taking an `int32`, I can happily change that.