### PR TITLE
Optimize `((a mod modulus) + modulus) mod modulo`

### DIFF
--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -1095,12 +1095,11 @@ func invmod*(a, modulus: BigInt): BigInt =
       r1 = a.modulo(modulus)
       t0 = zero
       t1 = one
+    var rk, tk: BigInt # otherwise t1 is incorrectly inferred as cursor (https://github.com/nim-lang/Nim/issues/19457)
     while r1 > 0:
-      let
-        q = r0 div r1
-        # the `q.isZero` check is needed because of an ARC/ORC bug (see https://github.com/nim-lang/bigints/issues/88)
-        rk = if q.isZero: r0 else: r0 - q * r1
-        tk = if q.isZero: t0 else: t0 - q * t1
+      let q = r0 div r1
+      rk = r0 - q * r1
+      tk = t0 - q * t1
       r0 = r1
       r1 = rk
       t0 = t1

--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -1127,7 +1127,7 @@ func powmod*(base, exponent, modulus: BigInt): BigInt =
     if exponent < 0:
       base = invmod(base, modulus)
       exponent = -exponent
-    var basePow = base.modulo(modulus) # base stays in [0, modulus-1]
+    var basePow = base.modulo(modulus)
     result = one
     while not exponent.isZero:
       if (exponent.limbs[0] and 1) != 0:


### PR DESCRIPTION
Avoids doing `mod` twice.

I also swapped `a.modulo(modulus)` and `modulus` in `invmod`, to skip the first iteration (otherwise `q` would always be zero in the first iteration, since `a.modulo(modulus) < modulus`).