### PR TITLE
Check that examples compile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,3 +28,4 @@ jobs:
           nim-version: ${{ matrix.nim-version }}
       - run: nimble install -y
       - run: nimble test
+      - run: nimble checkExamples

--- a/bigints.nimble
+++ b/bigints.nimble
@@ -18,3 +18,9 @@ task test, "Test bigints":
       echo "  using " & gc & " GC"
       for file in ["tbigints.nim", "tbugs.nim"]:
         exec "nim r --hints:off --experimental:strictFuncs --backend:" & backend & " --gc:" & gc & " tests/" & file
+
+task checkExamples, "Check examples":
+  echo "checking examples"
+  for example in listFiles("examples"):
+    if example.endsWith(".nim"):
+      exec "nim check --hints:off " & example


### PR DESCRIPTION
Followup to #73.

Check that all examples compile. This is a new nimble task, because it's not really testing the library, but it should be checked in the CI nevertheless. This only runs for the default backend & GC, since it's just making sure the examples compile, which should be mostly platform independent.