### PR TITLE
Benchmarks

### DIFF
--- a/benchmarks/benchBigints.nim
+++ b/benchmarks/benchBigints.nim
@@ -1,0 +1,61 @@
+import bigints
+import benchy
+import random
+
+block: # Bench random generation
+  randomize()
+  var n = 100
+  timeIt "bench Random generation of bigints with 100 limbs":
+    keep initRandomBigint(n)
+  timeIt "bench Random generation of bigints with 1_000 limbs":
+    keep initRandomBigint(n)
+  n = 5_000
+  timeIt "bench Random generation of bigints with 5_000 limbs":
+    keep initRandomBigint(n)
+  n = 10_000
+  timeIt "bench Random generation of bigints with 10_000 limbs":
+    keep initRandomBigint(n)
+block: # Bench multiplication
+  randomize()
+  var n = 100
+  timeIt "bench Multiplication of bigints with 100 limbs":
+    var a: Bigint = initRandomBigint(n)
+    var b: Bigint = initRandomBigint(n)
+    keep a*b
+  n = 1_000
+  timeIt "bench Multiplication of bigints with 1_000 limbs":
+    var a: Bigint = initRandomBigint(n)
+    var b: Bigint = initRandomBigint(n)
+    keep a*b
+  n = 5_000
+  timeIt "bench Multiplication of bigints with 5_000 limbs":
+    var a: Bigint = initRandomBigint(n)
+    var b: Bigint = initRandomBigint(n)
+    keep a*b
+  n = 10_000
+  timeIt "bench Multiplication of bigints with 10_000 limbs":
+    var a: Bigint = initRandomBigint(n)
+    var b: Bigint = initRandomBigint(n)
+    keep a*b
+block: # Bench division
+  randomize()
+  var n = 100
+  timeIt "bench Division of bigints with 100 limbs":
+    var a: Bigint = initRandomBigint(n)
+    var b: Bigint = initRandomBigint(n)
+    keep a div b
+  n = 1_000
+  timeIt "bench Division of bigints with 1_000 limbs":
+    var a: Bigint = initRandomBigint(n)
+    var b: Bigint = initRandomBigint(n)
+    keep a div b
+  n = 5_000
+  timeIt "bench Division of bigints with 5_000 limbs":
+    var a: Bigint = initRandomBigint(n)
+    var b: Bigint = initRandomBigint(n)
+    keep a div b
+  n = 10_000
+  timeIt "bench Division of bigints with 10_000 limbs":
+    var a: Bigint = initRandomBigint(n)
+    var b: Bigint = initRandomBigint(n)
+    keep a div b

--- a/benchmarks/benchExamples.nim
+++ b/benchmarks/benchExamples.nim
@@ -1,0 +1,35 @@
+import bigints
+import benchy
+from std/math import `^`
+import pidigits
+import rc_combperm
+
+block: # Binomial and permutations
+  timeIt "Permutation 1000, 969":
+    keep perm(1000, 969)
+
+  timeIt "Binomial computation 1000, 969":
+    keep comb(1000, 969)
+
+block: # Power computation
+  timeIt "Power computation of 5^4^3^2":
+    keep 5.initBigInt.pow 4 ^ (3 ^ 2)
+  timeIt "Powers of two":
+    var power = 2.initBigInt
+    for _ in 1 .. 128000:
+      power = power * 2.initBigInt
+
+block: # Pidigits example
+  timeIt "Computation of 100 digits of Pi":
+    var i = 0
+    while i < 100:
+      var d: int32 = findPiDigit()
+      inc(i)
+      eliminateDigit(d)
+  timeIt "Computation of 1000 digits of Pi":
+    var i = 0
+    while i < 1000:
+      var d: int32 = findPiDigit()
+      inc(i)
+      eliminateDigit(d)
+

--- a/benchmarks/nim.cfg
+++ b/benchmarks/nim.cfg
@@ -1,0 +1,2 @@
+path = "$projectPath/../src"
+path = "$projectPath/../examples"

--- a/bigints.nimble
+++ b/bigints.nimble
@@ -16,7 +16,7 @@ task test, "Test bigints":
     echo "testing " & backend & " backend"
     for gc in ["refc", "arc", "orc"]:
       echo "  using " & gc & " GC"
-      for file in ["tbigints.nim", "tbugs.nim"]:
+      for file in ["trandom.nim", "tbigints.nim", "tbugs.nim"]:
         exec "nim r --hints:off --experimental:strictFuncs --backend:" & backend & " --gc:" & gc & " tests/" & file
       exec "nim doc --hints:off --backend:" & backend & " --gc:" & gc & " src/bigints.nim"
 

--- a/bigints.nimble
+++ b/bigints.nimble
@@ -25,3 +25,20 @@ task checkExamples, "Check examples":
   for example in listFiles("examples"):
     if example.endsWith(".nim"):
       exec "nim check --hints:off " & example
+
+task benchAll, "Benchmark Library":
+  for backend in ["c", "cpp"]:
+    echo "Benchmarks with " & backend & " backend"
+    for gc in ["refc", "arc", "orc"]:
+      echo "Benchmark with " & gc & " garbage collector"
+      for benchmark in listFiles("benchmarks"):
+        if benchmark.endsWith(".nim"):
+          echo "Benchmark " & benchmark
+          exec "nim r --hints:off -d:danger --opt:speed -d:lto --backend:" & backend & " --gc:" & gc & " " & benchmark
+
+task benchOrcC, "Benchmark Library with orc garbage collector and C backend":
+  for benchmark in listFiles("benchmarks"):
+    if benchmark.endsWith(".nim"):
+      echo "Benchmark " & benchmark
+      exec "nim r --hints:off -d:danger --opt:speed -d:lto --backend:c --gc:orc " & benchmark
+

--- a/examples/elliptic.nim
+++ b/examples/elliptic.nim
@@ -35,7 +35,7 @@ proc ecDouble(a: tuple): (BigInt, BigInt) =
   lam = lam mod primeCurve
   result = (x, y)
 
-proc ecMultiply(genPoint: tuple, scalarHex: BigInt): (BigInt, BigInt) =
+proc ecMultiply*(genPoint: tuple, scalarHex: BigInt): (BigInt, BigInt) =
   if scalarHex == zero or scalarHex >= numberPoints:
     raise newException(Exception, "Invalid Scalar/Private Key")
   var
@@ -47,7 +47,7 @@ proc ecMultiply(genPoint: tuple, scalarHex: BigInt): (BigInt, BigInt) =
       q = ecAdd(q, genPoint)
   result = q
 
-proc main() =
+when isMainModule:
   let publicKey = ecMultiply(Gpoint, privKey)
 
   echo ""
@@ -65,5 +65,3 @@ proc main() =
   echo "the official Public Key - compressed:"
   echo if publicKey[1] mod two == one: "03" & publicKey[0].toString(base = 16).align(64, '0')
        else: "02" & publicKey[0].toString(base = 16).align(64, '0')
-
-main()

--- a/examples/pidigits.nim
+++ b/examples/pidigits.nim
@@ -34,7 +34,7 @@ proc extractDigit(): int32 =
 
   result = get(toInt[int32](tmp1 and mask))
 
-proc eliminateDigit(d: int32) =
+proc eliminateDigit*(d: int32) =
   acc -= den * d.initBigInt
   acc *= ten
   num *= ten
@@ -48,33 +48,34 @@ proc nextTerm() =
   den *= k2
   num *= k
 
-proc findPiDigit(): int32 =
+proc findPiDigit*(): int32 =
   result = -1
   while result < 0:
     nextTerm()
     result = extractDigit()
 
-var i = 0
-if paramCount() == 0:
-  # prints an infinite amount of pi digits
-  while true:
+when isMainModule:
+  var i = 0
+  if paramCount() == 0:
+    # prints an infinite amount of pi digits
+    while true:
+      var d: int32 = findPiDigit()
+      stdout.write chr(ord('0') + d)
+      inc i
+      if i == 40:
+        echo ""
+        i = 0
+      eliminateDigit(d)
+
+  let n = parseInt(paramStr(1))
+
+  if n <= 0:
+    quit("The number you entered is negative. Please specify a strictly positive number")
+
+  while i < n:
     var d: int32 = findPiDigit()
-    stdout.write chr(ord('0') + d)
-    inc i
-    if i == 40:
-      echo ""
-      i = 0
+    stdout.write(chr(ord('0') + d))
+    inc(i)
+    if i mod 40 == 0:
+      echo "\t:", i
     eliminateDigit(d)
-
-let n = parseInt(paramStr(1))
-
-if n <= 0:
-  quit("The number you entered is negative. Please specify a strictly positive number")
-
-while i < n:
-  var d: int32 = findPiDigit()
-  stdout.write(chr(ord('0') + d))
-  inc(i)
-  if i mod 40 == 0:
-    echo "\t:", i
-  eliminateDigit(d)

--- a/examples/rc_combperm.nim
+++ b/examples/rc_combperm.nim
@@ -1,7 +1,7 @@
 # Solution for https://rosettacode.org/wiki/Combinations_and_permutations
 import bigints
 
-proc perm(n, k: int32): BigInt =
+proc perm*(n, k: int32): BigInt =
   result = initBigInt(1)
   var
     k = initBigInt(n - k)
@@ -10,12 +10,13 @@ proc perm(n, k: int32): BigInt =
     result *= n
     dec n
 
-proc comb(n, k: int32): BigInt =
+proc comb*(n, k: int32): BigInt =
   result = perm(n, k)
   var k = initBigInt(k)
   while k > 0.initBigInt:
     result = result div k
     dec k
 
-echo "P(1000, 969) = ", perm(1000, 969)
-echo "C(1000, 969) = ", comb(1000, 969)
+when isMainModule:
+  echo "P(1000, 969) = ", perm(1000, 969)
+  echo "C(1000, 969) = ", comb(1000, 969)

--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -1,6 +1,6 @@
 ## Arbitrary precision integers.
 
-import std/[algorithm, bitops, math, options]
+import std/[algorithm, bitops, math, options, random]
 
 type
   BigInt* = object
@@ -1198,3 +1198,17 @@ func powmod*(base, exponent, modulus: BigInt): BigInt =
         result = (result * basePow) mod modulus
       basePow = (basePow * basePow) mod modulus
       exponent = exponent shr 1
+
+# proc initRandomBigInt*(nbits: Natural): BigInt =
+#   ## Initialize a standalone BigInt
+#   let n_limbs = nbits shr 5
+#   let remainingBits = nbits mod 32
+#   result.limbs.setLen(n_limbs)
+#   let mask: uint32 = 1'u32 shl (remainingBits) - 1
+#   for i in 0 ..< result.limbs.len-1:
+#     result.limbs[i] = rand(uint32)
+#   result.limbs[result.limbs.len-1] = rand(uint32) xor mask
+
+# when isMainModule:
+#   randomize()
+

--- a/tests/tbigints.nim
+++ b/tests/tbigints.nim
@@ -1,5 +1,6 @@
 import bigints
 import std/options
+import random
 
 const
   zero = initBigInt(0)
@@ -786,6 +787,11 @@ proc main() =
     doAssert pred(a, 3) == initBigInt(4)
     doAssert succ(a, 3) == initBigInt(10)
 
+  # block:
+  #   randomize()
+  #   let a: BigInt = initRandomBigInt(33)
+  #   echo a
 
-static: main()
+
+#static: main()
 main()

--- a/tests/trandom.nim
+++ b/tests/trandom.nim
@@ -1,0 +1,67 @@
+import bigints
+import random
+
+type
+  MemSizeUnit = enum
+    o, Kio, Mio, Gio
+
+const
+  zero = initBigInt(0)
+  one = initBigInt(1)
+  memSize = 2 # Max number of allocated memory for the tests
+  memSizeUnit = Mio # Unit in which memSize is expressed
+
+proc computeLimit(memSize: Natural, memSizeUnit: MemSizeUnit): Natural =
+  var factor = 1
+  for _ in 1..ord(memSizeUnit):
+    factor *= 1024
+  result = memSize * factor
+
+const
+  memLimit = computeLimit(memSize, memSizeUnit) # Number of octets
+  maxLimbs = memLimit div 8
+  maxBits = 4*memLimit
+
+proc main() =
+  randomize()
+
+  block:
+    let a: BigInt = initRandomBigInt(0, Bits)
+    doAssert a == zero
+    let b: BigInt = initRandomBigInt(1, Bits)
+    doAssert b == one
+
+  block:
+    for nBits in [29, 32, 1037]:
+      for _ in 1 .. 5: # Repeat probabilistic tests
+        let a: BigInt = initRandomBigInt(nBits, Bits)
+        doAssert fastLog2(a) == (nBits - 1)
+        doAssert (toString(a, 2)).len == nBits
+    # For bigger bigints, remove the test with slow conversion to string
+    for nBits in [rand(1..maxBits), 32*rand(1..maxLimbs)]:
+      for _ in 1 .. 5:
+        let a: BigInt = initRandomBigInt(nBits, Bits)
+        doAssert fastLog2(a) == (nBits - 1)
+
+  block:
+    for nLimbs in [1, 2, 3, 5, 10, 25, 100]:
+      for _ in 1 .. 5:
+        let a: BigInt = initRandomBigInt(nLimbs)
+        let n_bitsA = fastLog2(a) + 1
+        doAssert n_bitsA <= 32*nlimbs
+        doAssert n_bitsA > 32*(nlimbs-1)
+
+  block: # GCD properties but tested on random Bigints
+    let limitGCD = 100_000 # Special limit for the GCD, otherwise the tests run for hours
+    let (nBitsA, nBitsB, nBitsC) = (rand(1..limitGCD), rand(1..limitGCD), rand(1..limitGCD))
+    let a = initRandomBigInt(nBitsA, Bits)
+    let b = initRandomBigInt(nBitsB, Bits)
+    let c = initRandomBigInt(nBitsC, Bits)
+    doAssert gcd(a, b) == gcd(b, a)
+    doAssert gcd(a, zero) == a
+    doAssert gcd(a, a) == a
+    doAssert gcd(c * a, c * b) == c * gcd(a,b)
+    doAssert gcd(a, gcd(b, c)) == gcd(gcd(a, b), c)
+    doAssert gcd(a, b) == gcd(b, a mod b)
+
+main()


### PR DESCRIPTION
I benchmarked multiplication, division, random generation of bigints. Without flags, the operations are slow, with flags, the timings looks correct to me.
The code source quality of benchBigints.nim can be improved with templates to do less copy-paste in the future.
I have also changed some of the examples to import them (by exporting some procedures and using whenIsmainmodule) so that I can benchmark them.
I added some corresponding nimble tasks.
I use `-d:lto -d:danger --opt:speed` flags for benchmarks.
I consider using benchy for benchmarks is ok, it does not make it a dependency of the full library, it is only required for benchmarks.
This PR might be really useful for easy comparison of our changes to the library.