### PR TITLE
chore: split workflows

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -1,0 +1,29 @@
+---
+name: docs
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+env:
+  nim-version: 'stable'
+  nim-src: src/${{ github.event.repository.name }}.nim
+  deploy-dir: .gh-pages
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: ${{ env.nim-version }}
+      - run: nimble install -Y
+      - run: nimble doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
+      - name: "Copy to index.html"
+        run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html
+      - name: Deploy documents
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.deploy-dir }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,7 @@
+---
 name: test
 
+# yamllint disable-line rule:truthy
 on:
   - push
   - pull_request
@@ -28,30 +30,3 @@ jobs:
       - run: nimble install -y
       - run: nimble test
       - run: nimble checkExamples
-
-name: docs
-on:
-  push:
-    branches:
-      - master
-env:
-  nim-version: 'stable'
-  nim-src: src/${{ github.event.repository.name }}.nim
-  deploy-dir: .gh-pages
-jobs:
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: jiro4989/setup-nim-action@v1
-        with:
-          nim-version: ${{ env.nim-version }}
-      - run: nimble install -Y
-      - run: nimble doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
-      - name: "Copy to index.html"
-        run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html
-      - name: Deploy documents
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.deploy-dir }}


### PR DESCRIPTION
This PR is an attempt to fix the [`test.yaml`](https://github.com/nim-lang/bigints/blob/ca00f6da386af9ad7e3abf603c0201da6a014477/.github/workflows/test.yaml) workflow. It moves the `doc` part into a new file. Also I applied the `yamllint` suggestions (except the `line-length`).

The `test.yaml` part [_works on my side_](https://github.com/vil02/bigints/actions/runs/5414749807). I do not really have a way to verify the `doc.yaml` part.

#126 is related.