### PR TITLE
Update documentation link

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
 env:
-  nim-version: 'stable'
   nim-src: src/${{ github.event.repository.name }}.nim
   deploy-dir: .gh-pages
 jobs:
@@ -17,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: jiro4989/setup-nim-action@v1
         with:
-          nim-version: ${{ env.nim-version }}
+          nim-version: 'devel'
       - run: nimble install -Y
       - run: nimble doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"

--- a/readme.md
+++ b/readme.md
@@ -33,4 +33,4 @@ nimble install https://github.com/nim-lang/bigints
 
 ## Documentation
 
-The documentation is available at: https://nimdocs.com/nim-lang/bigints/bigints.html
+The documentation is available at https://nim-lang.github.io/bigints.


### PR DESCRIPTION
Closes #125.

Hosting the docs with GitHub Pages works now, so let's update the link.

I also changed the Nim version for the docgen to devel, so that we get the latest updates, such as automatic theme selection based on the OS preference.